### PR TITLE
Separate products synchronization from API quering

### DIFF
--- a/src/Warehouse/Application/AppConstants.cs
+++ b/src/Warehouse/Application/AppConstants.cs
@@ -1,0 +1,7 @@
+﻿namespace Application
+{
+    public static class AppConstants
+    {
+        public const string ProductsCacheKey = "Products";
+    }
+}

--- a/src/Warehouse/Application/Application.csproj
+++ b/src/Warehouse/Application/Application.csproj
@@ -6,4 +6,13 @@
     <Nullable>disable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="MediatR" Version="12.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Domain\Domain.csproj" />
+    <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Warehouse/Application/Features/Products/Query/GetProductsHandler.cs
+++ b/src/Warehouse/Application/Features/Products/Query/GetProductsHandler.cs
@@ -1,0 +1,24 @@
+﻿using Infrastructure.Cache;
+using MediatR;
+
+namespace Application.Features.Products.Query
+{
+    public class GetProductsHandler : IRequestHandler<GetProductsQuery, string>
+    {
+        private readonly ICacheProvider _cacheProvider;
+
+        public GetProductsHandler(ICacheProvider cacheProvider)
+        {
+            _cacheProvider = cacheProvider;
+        }
+
+        public Task<string> Handle(GetProductsQuery request, CancellationToken cancellationToken)
+        {
+            var filteredProducts = _cacheProvider.Get<string>(AppConstants.ProductsCacheKey);
+
+            //TODO --> do filtering and common info preparation
+
+            return Task.FromResult(filteredProducts);
+        }
+    }
+}

--- a/src/Warehouse/Application/Features/Products/Query/GetProductsQuery.cs
+++ b/src/Warehouse/Application/Features/Products/Query/GetProductsQuery.cs
@@ -1,0 +1,6 @@
+﻿using MediatR;
+
+namespace Application.Features.Products.Query
+{
+    public record GetProductsQuery(string filter) : IRequest<string>;
+}

--- a/src/Warehouse/Application/Features/Products/Synchronize/SyncProductsCommand.cs
+++ b/src/Warehouse/Application/Features/Products/Synchronize/SyncProductsCommand.cs
@@ -1,0 +1,6 @@
+﻿using MediatR;
+
+namespace Application.Features.Products.Synchronize
+{
+    public record SyncProductsCommand(string sourceUri) : IRequest;
+}

--- a/src/Warehouse/Application/Features/Products/Synchronize/SyncProductsHandler.cs
+++ b/src/Warehouse/Application/Features/Products/Synchronize/SyncProductsHandler.cs
@@ -1,0 +1,27 @@
+﻿using Infrastructure.Cache;
+using Infrastructure.Http;
+using MediatR;
+
+namespace Application.Features.Products.Synchronize
+{
+    public class SyncProductsHandler : IRequestHandler<SyncProductsCommand>
+    {
+        private readonly IRetrieveProductsService _retrieveProductsService;
+        private readonly ICacheProvider _cacheProvider;
+
+        public SyncProductsHandler(
+            IRetrieveProductsService retrieveProductsService, 
+            ICacheProvider cacheProvider)
+        {
+            _retrieveProductsService = retrieveProductsService;
+            _cacheProvider = cacheProvider;
+        }
+
+        public async Task Handle(SyncProductsCommand request, CancellationToken cancellationToken)
+        {
+            var products = await _retrieveProductsService.GetProducts(request.sourceUri, cancellationToken);
+
+            _cacheProvider.Set(AppConstants.ProductsCacheKey, products);
+        }
+    }
+}

--- a/src/Warehouse/Domain/Models/Product.cs
+++ b/src/Warehouse/Domain/Models/Product.cs
@@ -1,0 +1,6 @@
+﻿namespace Domain.Models
+{
+    public class Product
+    {
+    }
+}

--- a/src/Warehouse/Infrastructure/Cache/ICacheProvider.cs
+++ b/src/Warehouse/Infrastructure/Cache/ICacheProvider.cs
@@ -1,0 +1,9 @@
+﻿namespace Infrastructure.Cache
+{
+    public interface ICacheProvider
+    {
+        T Get<T>(string cacheKey);
+
+        void Set<T>(string cacheKey, T entity);
+    }
+}

--- a/src/Warehouse/Infrastructure/Cache/InMemoryCacheProvider.cs
+++ b/src/Warehouse/Infrastructure/Cache/InMemoryCacheProvider.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+
+namespace Infrastructure.Cache
+{
+    public class InMemoryCacheProvider : ICacheProvider
+    {
+        private readonly IMemoryCache _memoryCache;
+
+        public InMemoryCacheProvider(IMemoryCache memoryCache)
+        {
+            _memoryCache = memoryCache;
+        }
+
+        public T Get<T>(string cacheKey)
+        {
+            return (T)(_memoryCache.Get(cacheKey));
+        }
+
+        public void Set<T>(string cacheKey, T entity)
+        {
+            _memoryCache.Set(cacheKey, entity);
+        }
+    }
+}

--- a/src/Warehouse/Infrastructure/Http/IRetrieveProductsService.cs
+++ b/src/Warehouse/Infrastructure/Http/IRetrieveProductsService.cs
@@ -1,0 +1,7 @@
+﻿namespace Infrastructure.Http
+{
+    public interface IRetrieveProductsService
+    {
+        Task<string> GetProducts(string sourceUri, CancellationToken cancellationToken);
+    }
+}

--- a/src/Warehouse/Infrastructure/Http/RetrieveProductsService.cs
+++ b/src/Warehouse/Infrastructure/Http/RetrieveProductsService.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.Http
+{
+    public class RetrieveProductsService : IRetrieveProductsService
+    {
+        private readonly ILogger<RetrieveProductsService> _logger;
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public RetrieveProductsService(
+            ILogger<RetrieveProductsService> logger, 
+            IHttpClientFactory httpClientFactory)
+        {
+            _logger = logger;
+            _httpClientFactory = httpClientFactory;
+        }
+
+        public async Task<string> GetProducts(string sourceUri, CancellationToken cancellationToken)
+        {
+            var httpClient = _httpClientFactory.CreateClient();
+
+            var response = await httpClient.GetAsync(sourceUri, cancellationToken);
+
+            try
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    //TODO: deserialize before return to desired T type
+                    var stringResult = await response.Content.ReadAsStringAsync(cancellationToken);
+                    return stringResult;
+                }
+                else
+                {
+                    throw new Exception(response.StatusCode.ToString());
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve products from the source");
+                throw;
+            }
+        }
+    }
+}

--- a/src/Warehouse/Infrastructure/Infrastructure.csproj
+++ b/src/Warehouse/Infrastructure/Infrastructure.csproj
@@ -6,4 +6,9 @@
     <Nullable>disable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/Warehouse/WebApi/Background/ProductsSyncService.cs
+++ b/src/Warehouse/WebApi/Background/ProductsSyncService.cs
@@ -1,0 +1,43 @@
+﻿using Application.Features.Products.Synchronize;
+using MediatR;
+using Microsoft.Extensions.Options;
+using WebApi.Configuration;
+
+namespace WebApi.Background
+{
+    public class ProductsSyncService : BackgroundService
+    {
+        private readonly IMediator _mediator;
+        private readonly ILogger<ProductsSyncService> _logger;
+        private readonly ProductsSourceConfig _productsSourceConfig;
+
+        public ProductsSyncService(
+            IMediator mediator,
+            ILogger<ProductsSyncService> logger,
+            IOptions<ProductsSourceConfig> productsSourcs)
+        {
+            _logger = logger;
+            _productsSourceConfig = productsSourcs.Value;
+            _mediator = mediator;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            try
+            {
+                while (!stoppingToken.IsCancellationRequested)
+                {
+                    _logger.LogInformation("Retrieve information from the source...");
+
+                    await _mediator.Send(new SyncProductsCommand(_productsSourceConfig.Uri));
+
+                    await Task.Delay(TimeSpan.FromSeconds(_productsSourceConfig.RefreshTime), stoppingToken);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve information from the source: {Message}", ex.Message);
+            }
+        }
+    }
+}

--- a/src/Warehouse/WebApi/Configuration/MemoryCacheExtensions.cs
+++ b/src/Warehouse/WebApi/Configuration/MemoryCacheExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Infrastructure.Cache;
+
+namespace WebApi.Configuration
+{
+    public static class MemoryCacheExtensions
+    {
+        public static void AddMemoryCacheConfiguration(this IServiceCollection services)
+        {
+            services.AddMemoryCache();
+
+            services.AddSingleton<ICacheProvider, InMemoryCacheProvider>();
+        }
+    }
+}

--- a/src/Warehouse/WebApi/Configuration/ProductsSourceConfig.cs
+++ b/src/Warehouse/WebApi/Configuration/ProductsSourceConfig.cs
@@ -3,5 +3,7 @@
     public class ProductsSourceConfig
     {
         public string Uri { get; set; }
+
+        public int RefreshTime { get; set; }
     }
 }

--- a/src/Warehouse/WebApi/Program.cs
+++ b/src/Warehouse/WebApi/Program.cs
@@ -1,7 +1,12 @@
+using Application;
+using Application.Features.Products.Synchronize;
 using Domain.Common;
+using Infrastructure.Http;
+using WebApi.Background;
 using WebApi.Configuration;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddMemoryCacheConfiguration();
 
 //Set configuration
 var productSourceSection = builder.Configuration.GetSection(Constants.Configuration.ProductsSourceSection);
@@ -9,11 +14,17 @@ builder.Services.Configure<ProductsSourceConfig>(productSourceSection);
 
 // Add services to the container.
 builder.Services.AddHttpClient();
+builder.Services.AddHostedService<ProductsSyncService>();
+builder.Services.AddTransient<IRetrieveProductsService, RetrieveProductsService>();
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+//add MediatR
+builder.Services.AddMediatR(cfg =>
+     cfg.RegisterServicesFromAssembly(typeof(AppConstants).Assembly));
 
 var app = builder.Build();
 

--- a/src/Warehouse/WebApi/WebApi.csproj
+++ b/src/Warehouse/WebApi/WebApi.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Application\Application.csproj" />
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
 

--- a/src/Warehouse/WebApi/appsettings.json
+++ b/src/Warehouse/WebApi/appsettings.json
@@ -7,6 +7,7 @@
   },
   "AllowedHosts": "*",
   "ProductsSource": {
-    "Uri": "https://run.mocky.io/v3/97aa328f-6f5d-458a-9fa4-55fe58eaacc9"
+    "Uri": "https://run.mocky.io/v3/97aa328f-6f5d-458a-9fa4-55fe58eaacc9",
+    "RefreshTime": 10
   }
 }


### PR DESCRIPTION
Separate products synchronization from API quering and store it into the in memory cache. Products are retrieved every 10 sec.